### PR TITLE
Add restic updater CLI

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,0 +1,3 @@
+module backup
+
+go 1.24.3

--- a/src/main.go
+++ b/src/main.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type release struct {
+	TagName string `json:"tag_name"`
+	Assets  []struct {
+		Name               string `json:"name"`
+		BrowserDownloadURL string `json:"browser_download_url"`
+	} `json:"assets"`
+}
+
+func main() {
+	binDir := filepath.Join(".", "bin")
+	resticName := "restic"
+	if runtime.GOOS == "windows" {
+		resticName += ".exe"
+	}
+	resticPath := filepath.Join(binDir, resticName)
+
+	if _, err := os.Stat(resticPath); os.IsNotExist(err) {
+		fmt.Println("restic not found, downloading latest release...")
+		if err := downloadRestic(binDir, resticPath); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to download restic: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("restic downloaded to", resticPath)
+	} else {
+		fmt.Println("restic found, performing self-update...")
+		cmd := exec.Command(resticPath, "self-update")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "restic self-update failed: %v\n", err)
+			os.Exit(1)
+		}
+	}
+}
+
+func downloadRestic(binDir, resticPath string) error {
+	resp, err := http.Get("https://api.github.com/repos/restic/restic/releases/latest")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+
+	var rel release
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return err
+	}
+	version := strings.TrimPrefix(rel.TagName, "v")
+	goos := runtime.GOOS
+	arch := runtime.GOARCH
+	ext := ".tar.gz"
+	if goos == "windows" {
+		ext = ".zip"
+	}
+	targetName := fmt.Sprintf("restic_%s_%s_%s%s", version, goos, arch, ext)
+	var downloadURL string
+	for _, a := range rel.Assets {
+		if a.Name == targetName {
+			downloadURL = a.BrowserDownloadURL
+			break
+		}
+	}
+	if downloadURL == "" {
+		return fmt.Errorf("asset %s not found", targetName)
+	}
+
+	resp2, err := http.Get(downloadURL)
+	if err != nil {
+		return err
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed: %s", resp2.Status)
+	}
+
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return err
+	}
+
+	if ext == ".zip" {
+		data, err := io.ReadAll(resp2.Body)
+		if err != nil {
+			return err
+		}
+		z, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+		if err != nil {
+			return err
+		}
+		for _, f := range z.File {
+			if f.Name == "restic.exe" {
+				rc, err := f.Open()
+				if err != nil {
+					return err
+				}
+				out, err := os.OpenFile(resticPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+				if err != nil {
+					rc.Close()
+					return err
+				}
+				if _, err := io.Copy(out, rc); err != nil {
+					out.Close()
+					rc.Close()
+					return err
+				}
+				out.Close()
+				rc.Close()
+				break
+			}
+		}
+		return nil
+	}
+
+	gz, err := gzip.NewReader(resp2.Body)
+	if err != nil {
+		return err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if hdr.Typeflag == tar.TypeReg && hdr.Name == "restic" {
+			out, err := os.OpenFile(resticPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(out, tr); err != nil {
+				out.Close()
+				return err
+			}
+			out.Close()
+			break
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add Go command that ensures a local `restic` binary is available
- download latest `restic` release if missing, or self-update existing binary
- choose correct restic release for linux, macOS, or windows

## Testing
- `GOPROXY=off go fmt ./...`
- `GOPROXY=off go vet ./...`
- `GOPROXY=off go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6898aa508c4c8326900c24556da04925