### PR TITLE
Add layered config loading for restic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # backup
 Backup for friends and family of IT experts.
+
+## Configuration
+
+Configuration for the restic repository and password is loaded in the
+following order:
+
+1. Environment variables `RESTIC-REPO` and `RESTIC-REPO-PASSWORD`.
+2. A Pastebin document providing `restic-repo` and `restic-repo-password`.
+3. Embedded defaults pointing at `~/tmp/test-backup` with a test password.


### PR DESCRIPTION
## Summary
- embed default restic repo and password
- load configuration from environment or Pastebin before falling back to defaults
- document configuration order

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6898beae167c83269a695e3a196fd678