### PR TITLE
Add cross-platform auto-start support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # backup
 Backup for friends and family of IT experts.
 
+## Auto start
+
+When executed, the program configures itself to launch automatically at user login on Linux, macOS, and Windows.
+
 ## Configuration
 
 Configuration for the restic repository and password is loaded in the

--- a/src/autostart.go
+++ b/src/autostart.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+// ensureAutoStart configures the program to run at user login for the current OS.
+func ensureAutoStart() {
+	exePath, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "auto-start: executable: %v\n", err)
+		return
+	}
+	exePath, err = filepath.Abs(exePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "auto-start: abs: %v\n", err)
+		return
+	}
+
+	switch runtime.GOOS {
+	case "windows":
+		cmd := exec.Command("reg", "add",
+			`HKCU\Software\Microsoft\Windows\CurrentVersion\Run`,
+			"/v", "backup",
+			"/t", "REG_SZ",
+			"/d", exePath,
+			"/f",
+		)
+		_ = cmd.Run()
+	case "darwin":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "auto-start: home: %v\n", err)
+			return
+		}
+		dir := filepath.Join(home, "Library", "LaunchAgents")
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "auto-start: mkdir: %v\n", err)
+			return
+		}
+		plist := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>com.example.backup</string>
+    <key>ProgramArguments</key>
+    <array><string>%s</string></array>
+    <key>RunAtLoad</key><true/>
+</dict>
+</plist>
+`, exePath)
+		plistPath := filepath.Join(dir, "com.example.backup.plist")
+		_ = os.WriteFile(plistPath, []byte(plist), 0644)
+	default:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "auto-start: home: %v\n", err)
+			return
+		}
+		dir := filepath.Join(home, ".config", "autostart")
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "auto-start: mkdir: %v\n", err)
+			return
+		}
+		desktop := fmt.Sprintf(`[Desktop Entry]
+Type=Application
+Exec=%s
+Hidden=false
+NoDisplay=false
+X-GNOME-Autostart-enabled=true
+Name=backup
+Comment=Backup program
+`, exePath)
+		desktopPath := filepath.Join(dir, "backup.desktop")
+		_ = os.WriteFile(desktopPath, []byte(desktop), 0644)
+	}
+}

--- a/src/autostart_test.go
+++ b/src/autostart_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestEnsureAutoStartLinux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux only")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	ensureAutoStart()
+	desktop := filepath.Join(home, ".config", "autostart", "backup.desktop")
+	data, err := os.ReadFile(desktop)
+	if err != nil {
+		t.Fatalf("read desktop: %v", err)
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("executable: %v", err)
+	}
+	if !strings.Contains(string(data), exe) {
+		t.Fatalf("desktop missing executable: %s", data)
+	}
+}

--- a/src/main.go
+++ b/src/main.go
@@ -67,6 +67,7 @@ func defaultEmbeddedConfig() config {
 
 // main is the program entry point.
 func main() {
+	ensureAutoStart()
 	binDir := filepath.Join(".", "bin")
 	resticName := "restic"
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
## Summary
- add `ensureAutoStart` to register the program at user login for Windows, macOS, and Linux
- invoke the auto-start setup on program start and document the behavior
- test Linux autostart file creation

## Testing
- `cd src && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689986c8afcc8326a29318c2a7c4866e