### PR TITLE
Add version info, restic setup refactor, and notifications

### DIFF
--- a/src/notify.go
+++ b/src/notify.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/smtp"
+	"net/url"
+	"strings"
+)
+
+var pushoverURL = "https://api.pushover.net/1/messages.json"
+var httpClient = http.DefaultClient
+var smtpSendMail = smtp.SendMail
+
+func notify(cfg config, subject, message string) {
+	if cfg.PushoverToken != "" && cfg.PushoverUser != "" {
+		sendPushover(cfg, subject, message)
+	}
+	if cfg.EmailServer != "" && cfg.EmailUser != "" && cfg.EmailPassword != "" && cfg.EmailFrom != "" && cfg.EmailTo != "" {
+		sendEmail(cfg, subject, message)
+	}
+}
+
+func sendPushover(cfg config, title, message string) {
+	data := url.Values{}
+	data.Set("token", cfg.PushoverToken)
+	data.Set("user", cfg.PushoverUser)
+	data.Set("message", message)
+	if title != "" {
+		data.Set("title", title)
+	}
+	_, _ = httpClient.PostForm(pushoverURL, data)
+}
+
+func sendEmail(cfg config, subject, body string) {
+	addr := cfg.EmailServer
+	host := strings.Split(addr, ":")[0]
+	if !strings.Contains(addr, ":") {
+		addr = addr + ":587"
+	}
+	auth := smtp.PlainAuth("", cfg.EmailUser, cfg.EmailPassword, host)
+	msg := fmt.Sprintf("Subject: %s\r\n\r\n%s", subject, body)
+	_ = smtpSendMail(addr, auth, cfg.EmailFrom, []string{cfg.EmailTo}, []byte(msg))
+}

--- a/src/notify_test.go
+++ b/src/notify_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/smtp"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestNotify(t *testing.T) {
+	// setup fake Pushover server
+	var form url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		form = r.Form
+	}))
+	defer srv.Close()
+	oldURL := pushoverURL
+	pushoverURL = srv.URL
+	defer func() { pushoverURL = oldURL }()
+
+	// stub smtp
+	var called bool
+	oldSend := smtpSendMail
+	smtpSendMail = func(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
+		called = true
+		if addr != "smtp.example:25" {
+			t.Fatalf("unexpected addr %s", addr)
+		}
+		if from != "from" || len(to) != 1 || to[0] != "to" {
+			t.Fatalf("unexpected mail args")
+		}
+		if !strings.Contains(string(msg), "body") {
+			t.Fatalf("missing body in message")
+		}
+		return nil
+	}
+	defer func() { smtpSendMail = oldSend }()
+
+	cfg := config{
+		PushoverToken: "pt",
+		PushoverUser:  "pu",
+		EmailServer:   "smtp.example:25",
+		EmailUser:     "eu",
+		EmailPassword: "ep",
+		EmailFrom:     "from",
+		EmailTo:       "to",
+	}
+
+	notify(cfg, "title", "body")
+
+	if form == nil {
+		t.Fatalf("pushover not called")
+	}
+	if form.Get("token") != "pt" || form.Get("user") != "pu" || form.Get("message") != "body" || form.Get("title") != "title" {
+		t.Fatalf("unexpected pushover data: %v", form)
+	}
+	if !called {
+		t.Fatalf("smtp not called")
+	}
+}

--- a/src/version.go
+++ b/src/version.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+var (
+	Version   = "0.0.0-dev"
+	GitCommit = "unknown"
+)
+
+func printVersion() {
+	fmt.Printf("backup version %s (%s)\n", Version, GitCommit)
+}


### PR DESCRIPTION
## Summary
- Print semantic version and git fingerprint at startup
- Refactor restic download/self-update into `ensureRestic`
- Send backup status via email and Pushover when configured

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68999083dcf483269d8bf33850eab9ab