### PR TITLE
Add health check parameter to backup tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ following order:
 1. Environment variables `RESTIC-REPO` and `RESTIC-REPO-PASSWORD`.
 2. A Pastebin document providing `restic-repo` and `restic-repo-password`.
 3. Embedded defaults pointing at `~/tmp/test-backup` with a test password.
+
+## Health check
+
+Running the program with the `health` argument prints a detailed report about
+the environment and configuration. If email or Pushover notifications are
+configured, the report is sent through those channels as well.

--- a/src/health_test.go
+++ b/src/health_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHealthReport(t *testing.T) {
+	dir := t.TempDir()
+	restic := filepath.Join(dir, "restic")
+	if err := os.WriteFile(restic, []byte("#!/bin/sh\necho restic 0.9.6\n"), 0755); err != nil {
+		t.Fatalf("write restic: %v", err)
+	}
+	dataDir := filepath.Join(dir, "data")
+	if err := os.Mkdir(dataDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "f.txt"), []byte("hi"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	cfg := config{Paths: []string{dataDir}}
+	restore := withHTTPClient(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := `{"a":"b"}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header), Request: req}, nil
+	}))
+	defer restore()
+	rep := healthReport(restic, cfg)
+	if !strings.Contains(rep, "restic version: restic 0.9.6") {
+		t.Fatalf("report missing restic version: %s", rep)
+	}
+	if !strings.Contains(rep, "pushover configured: no") {
+		t.Fatalf("report missing pushover info: %s", rep)
+	}
+	if !strings.Contains(rep, "email configured: no") {
+		t.Fatalf("report missing email info: %s", rep)
+	}
+	if !strings.Contains(rep, "\"a\": \"b\"") {
+		t.Fatalf("report missing pastebin content: %s", rep)
+	}
+	if !strings.Contains(rep, "f.txt") {
+		t.Fatalf("report missing file listing: %s", rep)
+	}
+}


### PR DESCRIPTION
## Summary
- add `health` command that reports environment details and sends notifications
- implement health report with restic version, configuration checks, OS info, and file listing
- document health check usage

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68999bc4d5808326b315e4da9d534859