### PR TITLE
Hide file listings in health report

### DIFF
--- a/src/health_test.go
+++ b/src/health_test.go
@@ -41,7 +41,7 @@ func TestHealthReport(t *testing.T) {
 	if !strings.Contains(rep, "\"a\": \"b\"") {
 		t.Fatalf("report missing pastebin content: %s", rep)
 	}
-	if !strings.Contains(rep, "f.txt") {
-		t.Fatalf("report missing file listing: %s", rep)
+	if !strings.Contains(rep, dataDir) {
+		t.Fatalf("report missing backup path: %s", rep)
 	}
 }

--- a/src/main.go
+++ b/src/main.go
@@ -423,19 +423,10 @@ func healthReport(resticPath string, cfg config) string {
 		b.WriteString("username: " + u.Username + "\n")
 	}
 
-	b.WriteString("backup contents:\n")
+	b.WriteString("paths to backup:\n")
 	for _, p := range cfg.Paths {
 		exp := expandUser(p)
-		b.WriteString("path: " + exp + "\n")
-		filepath.Walk(exp, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return nil
-			}
-			if !info.IsDir() {
-				b.WriteString(" - " + path + "\n")
-			}
-			return nil
-		})
+		b.WriteString(" - " + exp + "\n")
 	}
 
 	return b.String()


### PR DESCRIPTION
## Summary
- Show only configured backup directories in health report
- Adjust health report test to expect directory paths

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899b7fed2ac8326bdb9ead93797bbb3